### PR TITLE
Use shape id to name layers

### DIFF
--- a/Sources/iOS/Item/Shape/ShapeAware.swift
+++ b/Sources/iOS/Item/Shape/ShapeAware.swift
@@ -2,6 +2,7 @@ import UIKit
 
 public protocol ShapeAware {
 
+  var id: String { get }
   var style: Style { get }
   var path: UIBezierPath { get }
 }
@@ -11,6 +12,7 @@ public extension ShapeAware {
   func layer() -> CAShapeLayer {
     let layer = CAShapeLayer()
     layer.path = path.cgPath
+    layer.name = id
 
     layer.strokeColor = style.strokeColor?.cgColor
     layer.lineWidth = style.strokeWidth


### PR DESCRIPTION
Hi! Thanks a lot for maintaining this lightweight SVG library, it's clean and really easy to use. 👏

Since I needed to discriminate paths based on their `id`, I have made a small change which will name the layers using the original value of `id`.

Is that something you'd consider adding to the main project?

Let me know if you need me to make some changes to the PR.